### PR TITLE
Add missing workout step field type

### DIFF
--- a/src/protocol/get_field_type.rs
+++ b/src/protocol/get_field_type.rs
@@ -1535,6 +1535,7 @@ fn match_field_workout_step(k: usize) -> FieldType {
         11 => FieldType::Uint16,
         12 => FieldType::Uint16,
         13 => FieldType::FitBaseUnit,
+        18 => FieldType::Uint8,
         19 => FieldType::WktStepTarget,
         20 => FieldType::Uint32,
         21 => FieldType::Uint32,


### PR DESCRIPTION
Field 18 is used to signal if the last step of a workout repeat should be skipped or not. 1 means skip, 0 means don't skip.

---

Thanks for this crate! I'm working on a tool to convert Garmin workout JSON to FIT files and this has helped me a lot! However I noticed some discrepancies for repeats where the last repeat should be skipped.

By syncing a workout to Garmin, extracting the FIT file and reading it back I saw that a data field in the `MessageType::WorkoutStep` data message for field `18` was set to `1`. It seems like this field is missing from the field type mapping resulting in the field type being set to `FieldType::None` and always 0.

I can't find any docs on this and it's not a part of `Profile.xlsx` from the SDK but I opened https://forums.garmin.com/developer/fit-sdk/f/discussion/424362/field-definition-for-skipping-last-repeat-on-workout as well to confirm the number.