### PR TITLE
Add support for reading developer data fields

### DIFF
--- a/examples/read_developer_fields.rs
+++ b/examples/read_developer_fields.rs
@@ -1,0 +1,29 @@
+use fit_rust::Fit;
+use fit_rust::protocol::FitMessage;
+use fit_rust::protocol::data_field::FieldNum;
+use fit_rust::protocol::message_type::MessageType;
+use std::fs;
+
+fn main() {
+    let file = fs::read("tests/test.fit").unwrap();
+    let fit: Fit = Fit::read(file).unwrap();
+    for data in &fit.data {
+        match data {
+            FitMessage::Definition(msg) => {
+                println!("Definition: {:?}", msg.data);
+            }
+            FitMessage::Data(msg) if msg.data.message_type == MessageType::FileId => {
+                println!("FileId data type: {:?}", msg.data);
+            }
+            FitMessage::Data(msg) if msg.data.message_type == MessageType::Record => {
+                for v in &msg.data.values {
+                    match v.field_num {
+                        FieldNum::GlobalProfile(field_num) => {}
+                        FieldNum::DeveloperData(dev_data_index, field_num) => {}
+                    }
+                }
+            }
+            FitMessage::Data(_) => {}
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,11 +5,11 @@ use crate::protocol::macros::get_field_value;
 use crate::protocol::message_type::MessageType;
 use crate::protocol::value::Value;
 use crate::protocol::{
-    calculate_fit_crc, DataMessage, DefinitionMessage, FitDataMessage, FitDefinitionMessage,
-    FitHeader, FitMessage, FitMessageHeader,
+    calculate_fit_crc, DataMessage, DefinitionMessage, FieldDefBaseType, FieldDescription,
+    FitDataMessage, FitDefinitionMessage, FitHeader, FitMessage, FitMessageHeader,
 };
 use binrw::{BinReaderExt, BinResult, BinWrite, Endian, Error};
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::fmt;
 use std::fmt::{Debug, Formatter};
 use std::fs::{read, write};
@@ -35,15 +35,13 @@ impl Fit {
         let mut cursor = Cursor::new(buf);
         let header: FitHeader = cursor.read_ne()?;
         let mut queue: VecDeque<(u8, FitDefinitionMessage)> = VecDeque::new();
+        let mut dev_field_descriptions: HashMap<(u8, u8), FieldDescription> = HashMap::new();
 
         let mut data: Vec<FitMessage> = Vec::new();
         loop {
             let message_header: FitMessageHeader = cursor.read_ne()?;
             match message_header.definition {
                 true => {
-                    if message_header.dev_fields {
-                        unimplemented!("message_header.dev_fields is unimplemented");
-                    }
                     let definition_message: DefinitionMessage =
                         cursor.read_ne_args((message_header.dev_fields,))?;
 
@@ -60,9 +58,49 @@ impl Fit {
                         None => continue,
                         Some((_, def)) => def,
                     };
-                    let data_message: DataMessage = cursor.read_ne_args((definition,))?;
+                    let data_message: DataMessage =
+                        cursor.read_ne_args((definition, &dev_field_descriptions))?;
                     if data_message.message_type == MessageType::None {
                         continue;
+                    }
+                    if data_message.message_type == MessageType::FieldDescription {
+                        // Save the developer field information
+                        let mut dev_field_description = FieldDescription {
+                            dev_data_index: 0,
+                            definition_number: 0,
+                            base_type: FieldDefBaseType::new(false, 0),
+                        };
+                        for field in data_message.values.iter() {
+                            match field.field_num {
+                                0 => {
+                                    if let Value::U8(val) = field.value {
+                                        dev_field_description.dev_data_index = val;
+                                    }
+                                }
+                                1 => {
+                                    if let Value::U8(val) = field.value {
+                                        dev_field_description.definition_number = val;
+                                    }
+                                }
+                                2 => {
+                                    let Value::U8(base_type_byte) = field.value else {
+                                        unreachable!("base_type is not a byte")
+                                    };
+                                    dev_field_description.base_type.val =
+                                        // Temp this actually needs parsing
+                                        // like FieldDefBaseType::from(base_type_byte);
+                                        base_type_byte & 31; //FIELD_DEFINITION_BASE_NUMBER;
+                                }
+                                _ => {}
+                            }
+                        }
+                        dev_field_descriptions.insert(
+                            (
+                                dev_field_description.dev_data_index,
+                                dev_field_description.definition_number,
+                            ),
+                            dev_field_description,
+                        );
                     }
                     data.push(FitMessage::Data(FitDataMessage {
                         header: message_header,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod protocol;
 
+use crate::protocol::data_field::FieldNum;
 use crate::protocol::io::{skip_bytes, write_bin};
 use crate::protocol::macros::get_field_value;
 use crate::protocol::message_type::MessageType;
@@ -71,27 +72,29 @@ impl Fit {
                             base_type: FieldDefBaseType::new(false, 0),
                         };
                         for field in data_message.values.iter() {
-                            match field.field_num {
-                                0 => {
-                                    if let Value::U8(val) = field.value {
-                                        dev_field_description.dev_data_index = val;
+                            if let FieldNum::GlobalProfile(field_num) = field.field_num {
+                                match field_num {
+                                    0 => {
+                                        if let Value::U8(val) = field.value {
+                                            dev_field_description.dev_data_index = val;
+                                        }
                                     }
-                                }
-                                1 => {
-                                    if let Value::U8(val) = field.value {
-                                        dev_field_description.definition_number = val;
+                                    1 => {
+                                        if let Value::U8(val) = field.value {
+                                            dev_field_description.definition_number = val;
+                                        }
                                     }
-                                }
-                                2 => {
-                                    let Value::U8(base_type_byte) = field.value else {
-                                        unreachable!("base_type is not a byte")
-                                    };
-                                    dev_field_description.base_type.val =
+                                    2 => {
+                                        let Value::U8(base_type_byte) = field.value else {
+                                            unreachable!("base_type is not a byte")
+                                        };
+                                        dev_field_description.base_type.val =
                                         // Temp this actually needs parsing
                                         // like FieldDefBaseType::from(base_type_byte);
                                         base_type_byte & 31; //FIELD_DEFINITION_BASE_NUMBER;
+                                    }
+                                    _ => {}
                                 }
-                                _ => {}
                             }
                         }
                         dev_field_descriptions.insert(
@@ -312,80 +315,164 @@ impl Fit {
         for session in sessions {
             merge_stats!(
                 // max
-                max 253, max_stop_timestamp, session,
-                max 15, max_speed, session,
-                max 21, max_power, session,
-                max 50, max_altitude, session,
-                max 55, max_pos_grade, session,
-                max 56, max_neg_grade, session,
-                max 17, max_heart_rate, session,
-                max 19, max_cadence, session,
-                max 58, max_temperature, session,
+                max FieldNum::GlobalProfile(253), max_stop_timestamp, session,
+                max FieldNum::GlobalProfile(15), max_speed, session,
+                max FieldNum::GlobalProfile(21), max_power, session,
+                max FieldNum::GlobalProfile(50), max_altitude, session,
+                max FieldNum::GlobalProfile(55), max_pos_grade, session,
+                max FieldNum::GlobalProfile(56), max_neg_grade, session,
+                max FieldNum::GlobalProfile(17), max_heart_rate, session,
+                max FieldNum::GlobalProfile(19), max_cadence, session,
+                max FieldNum::GlobalProfile(58), max_temperature, session,
                 // min
-                min 2, min_start_timestamp, session,
-                min 71, min_altitude, session,
-                min 64, min_heart_rate, session,
+                min FieldNum::GlobalProfile(2), min_start_timestamp, session,
+                min FieldNum::GlobalProfile(71), min_altitude, session,
+                min FieldNum::GlobalProfile(64), min_heart_rate, session,
                 // sum
-                sum 7, total_elapsed_time, session,
-                sum 8, total_timer_time, session,
-                sum 9, total_distance, session,
-                sum 59, total_moving_time, session,
-                sum 11, total_calories, session,
-                sum 22, total_ascent, session,
-                sum 23, total_descent, session,
+                sum FieldNum::GlobalProfile(7), total_elapsed_time, session,
+                sum FieldNum::GlobalProfile(8), total_timer_time, session,
+                sum FieldNum::GlobalProfile(9), total_distance, session,
+                sum FieldNum::GlobalProfile(59), total_moving_time, session,
+                sum FieldNum::GlobalProfile(11), total_calories, session,
+                sum FieldNum::GlobalProfile(22), total_ascent, session,
+                sum FieldNum::GlobalProfile(23), total_descent, session,
                 // avg
-                avg 14, avg_speed, avg_speed_count, session,
-                avg 20, avg_power, avg_power_count, session,
-                avg 34, normal_power, normal_power_count, session,
-                avg 49, avg_altitude, avg_altitude_count, session,
-                avg 52, avg_grade, avg_grade_count, session,
-                avg 53, avg_pos_grade, avg_pos_grade_count, session,
-                avg 54, avg_neg_grade, avg_neg_grade_count, session,
-                avg 60, avg_pos_vertical_speed, avg_pos_vertical_speed_count, session,
-                avg 61, avg_neg_vertical_speed, avg_neg_vertical_speed_count, session,
-                avg 16, avg_heart_rate, avg_heart_rate_count, session,
-                avg 18, avg_cadence, avg_cadence_count, session,
-                avg 57, avg_temperature, avg_temperature_count, session,
+                avg FieldNum::GlobalProfile(14), avg_speed, avg_speed_count, session,
+                avg FieldNum::GlobalProfile(20), avg_power, avg_power_count, session,
+                avg FieldNum::GlobalProfile(34), normal_power, normal_power_count, session,
+                avg FieldNum::GlobalProfile(49), avg_altitude, avg_altitude_count, session,
+                avg FieldNum::GlobalProfile(52), avg_grade, avg_grade_count, session,
+                avg FieldNum::GlobalProfile(53), avg_pos_grade, avg_pos_grade_count, session,
+                avg FieldNum::GlobalProfile(54), avg_neg_grade, avg_neg_grade_count, session,
+                avg FieldNum::GlobalProfile(60), avg_pos_vertical_speed, avg_pos_vertical_speed_count, session,
+                avg FieldNum::GlobalProfile(61), avg_neg_vertical_speed, avg_neg_vertical_speed_count, session,
+                avg FieldNum::GlobalProfile(16), avg_heart_rate, avg_heart_rate_count, session,
+                avg FieldNum::GlobalProfile(18), avg_cadence, avg_cadence_count, session,
+                avg FieldNum::GlobalProfile(57), avg_temperature, avg_temperature_count, session,
             );
         }
 
         // Update merged session fields
         // max
-        update_field!(merged_session.data.values, 253, max_stop_timestamp);
-        update_field!(merged_session.data.values, 15, max_speed);
-        update_field!(merged_session.data.values, 21, max_power);
-        update_field!(merged_session.data.values, 50, max_altitude);
-        update_field!(merged_session.data.values, 55, max_pos_grade);
-        update_field!(merged_session.data.values, 56, max_neg_grade);
-        update_field!(merged_session.data.values, 17, max_heart_rate);
-        update_field!(merged_session.data.values, 19, max_cadence);
-        update_field!(merged_session.data.values, 58, max_temperature);
+        update_field!(
+            merged_session.data.values,
+            FieldNum::GlobalProfile(253),
+            max_stop_timestamp
+        );
+        update_field!(
+            merged_session.data.values,
+            FieldNum::GlobalProfile(15),
+            max_speed
+        );
+        update_field!(
+            merged_session.data.values,
+            FieldNum::GlobalProfile(21),
+            max_power
+        );
+        update_field!(
+            merged_session.data.values,
+            FieldNum::GlobalProfile(50),
+            max_altitude
+        );
+        update_field!(
+            merged_session.data.values,
+            FieldNum::GlobalProfile(55),
+            max_pos_grade
+        );
+        update_field!(
+            merged_session.data.values,
+            FieldNum::GlobalProfile(56),
+            max_neg_grade
+        );
+        update_field!(
+            merged_session.data.values,
+            FieldNum::GlobalProfile(17),
+            max_heart_rate
+        );
+        update_field!(
+            merged_session.data.values,
+            FieldNum::GlobalProfile(19),
+            max_cadence
+        );
+        update_field!(
+            merged_session.data.values,
+            FieldNum::GlobalProfile(58),
+            max_temperature
+        );
         // min
-        update_field!(merged_session.data.values, 2, min_start_timestamp);
-        update_field!(merged_session.data.values, 71, min_altitude);
-        update_field!(merged_session.data.values, 64, min_heart_rate);
+        update_field!(
+            merged_session.data.values,
+            FieldNum::GlobalProfile(2),
+            min_start_timestamp
+        );
+        update_field!(
+            merged_session.data.values,
+            FieldNum::GlobalProfile(71),
+            min_altitude
+        );
+        update_field!(
+            merged_session.data.values,
+            FieldNum::GlobalProfile(64),
+            min_heart_rate
+        );
         // sum
-        update_field!(merged_session.data.values, 7, total_elapsed_time);
-        update_field!(merged_session.data.values, 8, total_timer_time);
-        update_field!(merged_session.data.values, 9, total_distance);
-        update_field!(merged_session.data.values, 59, total_moving_time);
-        update_field!(merged_session.data.values, 11, total_calories);
-        update_field!(merged_session.data.values, 22, total_ascent);
-        update_field!(merged_session.data.values, 23, total_descent);
+        update_field!(
+            merged_session.data.values,
+            FieldNum::GlobalProfile(7),
+            total_elapsed_time
+        );
+        update_field!(
+            merged_session.data.values,
+            FieldNum::GlobalProfile(8),
+            total_timer_time
+        );
+        update_field!(
+            merged_session.data.values,
+            FieldNum::GlobalProfile(9),
+            total_distance
+        );
+        update_field!(
+            merged_session.data.values,
+            FieldNum::GlobalProfile(59),
+            total_moving_time
+        );
+        update_field!(
+            merged_session.data.values,
+            FieldNum::GlobalProfile(11),
+            total_calories
+        );
+        update_field!(
+            merged_session.data.values,
+            FieldNum::GlobalProfile(22),
+            total_ascent
+        );
+        update_field!(
+            merged_session.data.values,
+            FieldNum::GlobalProfile(23),
+            total_descent
+        );
         // avg
         if avg_speed_count > 0 {
             let avg_speed = <Value as Into<i32>>::into(avg_speed).div(avg_speed_count);
-            update_field!(merged_session.data.values, 14, Value::U16(avg_speed as u16));
+            update_field!(
+                merged_session.data.values,
+                FieldNum::GlobalProfile(14),
+                Value::U16(avg_speed as u16)
+            );
         }
         if avg_power_count > 0 {
             let avg_power = <Value as Into<i32>>::into(avg_power).div(avg_power_count);
-            update_field!(merged_session.data.values, 20, Value::U16(avg_power as u16));
+            update_field!(
+                merged_session.data.values,
+                FieldNum::GlobalProfile(20),
+                Value::U16(avg_power as u16)
+            );
         }
         if normal_power_count > 0 {
             let normal_power = <Value as Into<i32>>::into(normal_power).div(normal_power_count);
             update_field!(
                 merged_session.data.values,
-                34,
+                FieldNum::GlobalProfile(34),
                 Value::U16(normal_power as u16)
             );
         }
@@ -393,19 +480,23 @@ impl Fit {
             let avg_altitude = <Value as Into<i32>>::into(avg_altitude).div(avg_altitude_count);
             update_field!(
                 merged_session.data.values,
-                49,
+                FieldNum::GlobalProfile(49),
                 Value::U16(avg_altitude as u16)
             );
         }
         if avg_grade_count > 0 {
             let avg_grade = <Value as Into<i32>>::into(avg_grade).div(avg_grade_count);
-            update_field!(merged_session.data.values, 52, Value::I16(avg_grade as i16));
+            update_field!(
+                merged_session.data.values,
+                FieldNum::GlobalProfile(52),
+                Value::I16(avg_grade as i16)
+            );
         }
         if avg_pos_grade_count > 0 {
             let avg_pos_grade = <Value as Into<i32>>::into(avg_pos_grade).div(avg_pos_grade_count);
             update_field!(
                 merged_session.data.values,
-                53,
+                FieldNum::GlobalProfile(53),
                 Value::I16(avg_pos_grade as i16)
             );
         }
@@ -413,7 +504,7 @@ impl Fit {
             let avg_neg_grade = <Value as Into<i32>>::into(avg_neg_grade).div(avg_neg_grade_count);
             update_field!(
                 merged_session.data.values,
-                54,
+                FieldNum::GlobalProfile(54),
                 Value::I16(avg_neg_grade as i16)
             );
         }
@@ -422,7 +513,7 @@ impl Fit {
                 .div(avg_pos_vertical_speed_count);
             update_field!(
                 merged_session.data.values,
-                60,
+                FieldNum::GlobalProfile(60),
                 Value::I16(avg_pos_vertical_speed as i16)
             );
         }
@@ -431,7 +522,7 @@ impl Fit {
                 .div(avg_neg_vertical_speed_count);
             update_field!(
                 merged_session.data.values,
-                61,
+                FieldNum::GlobalProfile(61),
                 Value::I16(avg_neg_vertical_speed as i16)
             );
         }
@@ -440,20 +531,24 @@ impl Fit {
                 <Value as Into<i32>>::into(avg_heart_rate).div(avg_heart_rate_count);
             update_field!(
                 merged_session.data.values,
-                16,
+                FieldNum::GlobalProfile(16),
                 Value::U8(avg_heart_rate as u8)
             );
         }
         if avg_cadence_count > 0 {
             let avg_cadence = <Value as Into<i32>>::into(avg_cadence).div(avg_cadence_count);
-            update_field!(merged_session.data.values, 18, Value::U8(avg_cadence as u8));
+            update_field!(
+                merged_session.data.values,
+                FieldNum::GlobalProfile(18),
+                Value::U8(avg_cadence as u8)
+            );
         }
         if avg_temperature_count > 0 {
             let avg_temperature =
                 <Value as Into<i32>>::into(avg_temperature).div(avg_temperature_count);
             update_field!(
                 merged_session.data.values,
-                57,
+                FieldNum::GlobalProfile(57),
                 Value::I8(avg_temperature as i8)
             );
         }

--- a/src/protocol/data_field.rs
+++ b/src/protocol/data_field.rs
@@ -21,9 +21,15 @@ use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
 use std::io::{Read, Seek, Write};
 
+#[derive(Clone, Debug, PartialEq)]
+pub enum FieldNum {
+    GlobalProfile(u8),
+    DeveloperData(u8, u8),
+}
+
 #[derive(Clone, PartialEq)]
 pub struct DataField {
-    pub field_num: u8,
+    pub field_num: FieldNum,
 
     pub value: Value,
 }
@@ -35,7 +41,7 @@ impl Debug for DataField {
 }
 
 impl DataField {
-    pub fn new(fnum: u8, v: Value) -> Self {
+    pub fn new(fnum: FieldNum, v: Value) -> Self {
         Self {
             field_num: fnum,
             value: v,
@@ -60,24 +66,34 @@ impl DataField {
         } else {
             for fd in fields.iter() {
                 let data = DataField::read_next_field(fd.size, fd.base_type.val, reader, endian);
-                values
-                    .alloc()
-                    .init(DataField::new(fd.definition_number, data));
+                values.alloc().init(DataField::new(
+                    FieldNum::GlobalProfile(fd.definition_number),
+                    data,
+                ));
             }
             for dfd in dev_fields.as_ref().unwrap_or(&Vec::new()).iter() {
                 let field_desc = &dev_field_descriptions[&(dfd.dev_data_index, dfd.field_number)];
                 let data =
                     DataField::read_next_field(dfd.size, field_desc.base_type.val, reader, endian);
-                values
-                    .alloc()
-                    .init(DataField::new(field_desc.definition_number, data));
+                values.alloc().init(DataField::new(
+                    FieldNum::DeveloperData(
+                        field_desc.dev_data_index,
+                        field_desc.definition_number,
+                    ),
+                    data,
+                ));
             }
             // check each value in case the raw value needs further processing
             let scales = get_field_scale_fn(message_type);
             let offsets = get_field_offset_fn(message_type);
             let fields = get_field_type_fn(message_type);
             for v in &mut values {
-                DataField::process_read_value(v, fields, scales, offsets);
+                match v.field_num {
+                    FieldNum::GlobalProfile(_) => {
+                        DataField::process_read_value(v, fields, scales, offsets);
+                    }
+                    FieldNum::DeveloperData(_, _) => {}
+                }
             }
         }
         // values.shrink_to_fit();
@@ -337,50 +353,54 @@ impl DataField {
         scales: MatchScaleFn,
         offsets: MatchOffsetFn,
     ) {
-        match fields(v.field_num as usize) {
-            FieldType::None => (),
-            FieldType::Coordinates => {
-                if let Value::I32(ref inner) = v.value {
-                    let coord = *inner as f32 * COORD_SEMICIRCLES_CALC;
-                    std::mem::replace(&mut v.value, Value::F32(coord));
-                }
-            }
-            FieldType::Timestamp | FieldType::DateTime => {
-                if let Value::U32(ref inner) = v.value {
-                    let date = *inner + PSEUDO_EPOCH;
-                    std::mem::replace(&mut v.value, Value::Time(date));
-                }
-            }
-            FieldType::LocalDateTime => {
-                if let Value::U32(ref inner) = v.value {
-                    let time = *inner + PSEUDO_EPOCH - 3600;
-                    std::mem::replace(&mut v.value, Value::Time(time));
-                }
-            }
-            FieldType::String | FieldType::LocaltimeIntoDay => {}
-            FieldType::Uint8
-            | FieldType::Uint8Z
-            | FieldType::Uint16
-            | FieldType::Uint16Z
-            | FieldType::Uint32
-            | FieldType::Uint32Z
-            | FieldType::Sint8 => {
-                if let Some(s) = scales(v.field_num as usize) {
-                    v.value.scale(s);
-                }
-                if let Some(o) = offsets(v.field_num as usize) {
-                    v.value.offset(o);
-                }
-            }
-            FieldType::FitBaseType => {}
-            f => {
-                if let Value::U8(k) = v.value {
-                    if let Some(t) = get_field_string_value(f, usize::from(k)) {
-                        std::mem::replace(&mut v.value, Value::Enum(t));
+        if let FieldNum::GlobalProfile(field_num) = v.field_num {
+            match fields(field_num as usize) {
+                FieldType::None => (),
+                FieldType::Coordinates => {
+                    if let Value::I32(ref inner) = v.value {
+                        let coord = *inner as f32 * COORD_SEMICIRCLES_CALC;
+                        std::mem::replace(&mut v.value, Value::F32(coord));
                     }
-                } else if let Value::U16(k) = v.value {
-                    if let Some(t) = get_field_string_value(f, usize::from(k)) {
-                        std::mem::replace(&mut v.value, Value::Enum(t));
+                }
+                FieldType::Timestamp | FieldType::DateTime => {
+                    if let Value::U32(ref inner) = v.value {
+                        if (*inner as u64 + PSEUDO_EPOCH as u64) < (u32::MAX as u64) {
+                            let date = *inner + PSEUDO_EPOCH;
+                            std::mem::replace(&mut v.value, Value::Time(date));
+                        }
+                    }
+                }
+                FieldType::LocalDateTime => {
+                    if let Value::U32(ref inner) = v.value {
+                        let time = *inner + PSEUDO_EPOCH - 3600;
+                        std::mem::replace(&mut v.value, Value::Time(time));
+                    }
+                }
+                FieldType::String | FieldType::LocaltimeIntoDay => {}
+                FieldType::Uint8
+                | FieldType::Uint8Z
+                | FieldType::Uint16
+                | FieldType::Uint16Z
+                | FieldType::Uint32
+                | FieldType::Uint32Z
+                | FieldType::Sint8 => {
+                    if let Some(s) = scales(field_num as usize) {
+                        v.value.scale(s);
+                    }
+                    if let Some(o) = offsets(field_num as usize) {
+                        v.value.offset(o);
+                    }
+                }
+                FieldType::FitBaseType => {}
+                f => {
+                    if let Value::U8(k) = v.value {
+                        if let Some(t) = get_field_string_value(f, usize::from(k)) {
+                            std::mem::replace(&mut v.value, Value::Enum(t));
+                        }
+                    } else if let Value::U16(k) = v.value {
+                        if let Some(t) = get_field_string_value(f, usize::from(k)) {
+                            std::mem::replace(&mut v.value, Value::Enum(t));
+                        }
                     }
                 }
             }
@@ -394,68 +414,71 @@ impl DataField {
         offsets: MatchOffsetFn,
         def_field: Option<&FieldDefinition>,
     ) -> Value {
-        match fields(v.field_num as usize) {
-            FieldType::None => Value::None,
-            FieldType::Coordinates => {
-                if let Value::F32(ref inner) = v.value {
-                    let coord = *inner / COORD_SEMICIRCLES_CALC;
-                    return Value::I32(coord as i32);
+        match v.field_num {
+            FieldNum::GlobalProfile(field_num) => match fields(field_num as usize) {
+                FieldType::None => Value::None,
+                FieldType::Coordinates => {
+                    if let Value::F32(ref inner) = v.value {
+                        let coord = *inner / COORD_SEMICIRCLES_CALC;
+                        return Value::I32(coord as i32);
+                    }
+                    Value::None
                 }
-                Value::None
-            }
-            FieldType::DateTime | FieldType::Timestamp => {
-                if let Value::Time(ref inner) = v.value {
-                    let date = *inner - PSEUDO_EPOCH;
-                    return Value::U32(date);
+                FieldType::DateTime | FieldType::Timestamp => {
+                    if let Value::Time(ref inner) = v.value {
+                        let date = *inner - PSEUDO_EPOCH;
+                        return Value::U32(date);
+                    }
+                    Value::None
                 }
-                Value::None
-            }
-            FieldType::LocalDateTime => {
-                if let Value::Time(ref inner) = v.value {
-                    let date = *inner - PSEUDO_EPOCH + 3600;
-                    return Value::U32(date);
+                FieldType::LocalDateTime => {
+                    if let Value::Time(ref inner) = v.value {
+                        let date = *inner - PSEUDO_EPOCH + 3600;
+                        return Value::U32(date);
+                    }
+                    Value::None
                 }
-                Value::None
-            }
-            FieldType::String | FieldType::LocaltimeIntoDay => v.clone().value,
-            FieldType::Uint8
-            | FieldType::Uint8Z
-            | FieldType::Uint16
-            | FieldType::Uint16Z
-            | FieldType::Uint32
-            | FieldType::Uint32Z
-            | FieldType::Sint8 => {
-                let mut v = v.clone();
-                if let Some(s) = scales(v.field_num as usize) {
-                    v.value.rescale(s);
+                FieldType::String | FieldType::LocaltimeIntoDay => v.clone().value,
+                FieldType::Uint8
+                | FieldType::Uint8Z
+                | FieldType::Uint16
+                | FieldType::Uint16Z
+                | FieldType::Uint32
+                | FieldType::Uint32Z
+                | FieldType::Sint8 => {
+                    let mut v = v.clone();
+                    if let Some(s) = scales(field_num as usize) {
+                        v.value.rescale(s);
+                    }
+                    if let Some(o) = offsets(field_num as usize) {
+                        v.value.reoffset(o);
+                    }
+                    v.value
                 }
-                if let Some(o) = offsets(v.field_num as usize) {
-                    v.value.reoffset(o);
-                }
-                v.value
-            }
-            f => {
-                let v = v.clone();
-                if let Value::Enum(k) = v.value {
-                    if let Some(t) = get_field_key_from_string(f, k) {
-                        match def_field {
-                            None => {}
-                            Some(def_field) => {
-                                if def_field.size == 1 {
-                                    return Value::U8(t as u8);
-                                } else if def_field.size == 2 {
-                                    return Value::U16(t as u16);
-                                } else if def_field.size == 4 {
-                                    return Value::U32(t as u32);
-                                } else if def_field.size == 8 {
-                                    return Value::U64(t as u64);
+                f => {
+                    let v = v.clone();
+                    if let Value::Enum(k) = v.value {
+                        if let Some(t) = get_field_key_from_string(f, k) {
+                            match def_field {
+                                None => {}
+                                Some(def_field) => {
+                                    if def_field.size == 1 {
+                                        return Value::U8(t as u8);
+                                    } else if def_field.size == 2 {
+                                        return Value::U16(t as u16);
+                                    } else if def_field.size == 4 {
+                                        return Value::U32(t as u32);
+                                    } else if def_field.size == 8 {
+                                        return Value::U64(t as u64);
+                                    }
                                 }
                             }
                         }
                     }
+                    v.value
                 }
-                v.value
-            }
+            },
+            FieldNum::DeveloperData(_, _) => v.value.clone(),
         }
     }
 

--- a/src/protocol/data_field.rs
+++ b/src/protocol/data_field.rs
@@ -12,10 +12,12 @@ use crate::protocol::io::{
 use crate::protocol::message_type::MessageType;
 use crate::protocol::value::Value;
 use crate::protocol::{
-    DefinitionMessage, FieldDefinition, MatchFieldTypeFn, MatchOffsetFn, MatchScaleFn,
+    DefinitionMessage, DevFieldDefinition, FieldDefinition, FieldDescription, MatchFieldTypeFn,
+    MatchOffsetFn, MatchScaleFn,
 };
 use binrw::{BinResult, Endian};
 use copyless::VecHelper;
+use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
 use std::io::{Read, Seek, Write};
 
@@ -44,6 +46,8 @@ impl DataField {
     pub fn parse_data_field(
         message_type: MessageType,
         fields: &Vec<FieldDefinition>,
+        dev_fields: &Option<Vec<DevFieldDefinition>>,
+        dev_field_descriptions: &HashMap<(u8, u8), FieldDescription>,
     ) -> BinResult<Vec<DataField>> {
         let mut values = Vec::with_capacity(fields.len());
         if message_type == MessageType::None {
@@ -59,6 +63,14 @@ impl DataField {
                 values
                     .alloc()
                     .init(DataField::new(fd.definition_number, data));
+            }
+            for dfd in dev_fields.as_ref().unwrap_or(&Vec::new()).iter() {
+                let field_desc = &dev_field_descriptions[&(dfd.dev_data_index, dfd.field_number)];
+                let data =
+                    DataField::read_next_field(dfd.size, field_desc.base_type.val, reader, endian);
+                values
+                    .alloc()
+                    .init(DataField::new(field_desc.definition_number, data));
             }
             // check each value in case the raw value needs further processing
             let scales = get_field_scale_fn(message_type);
@@ -360,6 +372,7 @@ impl DataField {
                     v.value.offset(o);
                 }
             }
+            FieldType::FitBaseType => {}
             f => {
                 if let Value::U8(k) = v.value {
                     if let Some(t) = get_field_string_value(f, usize::from(k)) {

--- a/src/protocol/macros.rs
+++ b/src/protocol/macros.rs
@@ -1,4 +1,4 @@
-use crate::protocol::data_field::DataField;
+use crate::protocol::data_field::{DataField, FieldNum};
 use crate::protocol::value::Value;
 
 // Helper functions and macros for the merge_sessions function
@@ -11,7 +11,7 @@ macro_rules! update_field {
     };
 }
 
-pub fn get_field_value(field_num: u8, values: &[DataField]) -> Option<Value> {
+pub fn get_field_value(field_num: FieldNum, values: &[DataField]) -> Option<Value> {
     values
         .iter()
         .find(|field| field.field_num == field_num)

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -18,6 +18,7 @@ use crate::protocol::data_field::DataField;
 use crate::protocol::get_field_string_value::FieldType;
 use crate::protocol::message_type::MessageType;
 use binrw::{binrw, BinRead, BinResult, BinWrite, Endian};
+use std::collections::HashMap;
 use std::fmt::Debug;
 use std::io::{Seek, Write};
 
@@ -64,6 +65,12 @@ pub enum FitMessage {
 pub struct FitDefinitionMessage {
     pub header: FitMessageHeader,
     pub data: DefinitionMessage,
+}
+
+pub struct FieldDescription {
+    pub dev_data_index: u8,
+    pub definition_number: u8,
+    pub base_type: FieldDefBaseType,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -135,12 +142,12 @@ pub struct FitDataMessage {
 }
 
 #[derive(Clone, Debug, PartialEq, BinRead)]
-#[br(import(definition: &FitDefinitionMessage))]
+#[br(import(definition: &FitDefinitionMessage, dev_field_descriptions: &HashMap<(u8,u8), FieldDescription>))]
 pub struct DataMessage {
     #[br(parse_with = message_type::parse_message_type, args(definition.data.global_message_number))]
     pub message_type: MessageType,
 
-    #[br(parse_with = DataField::parse_data_field, args(message_type, &definition.data.fields), is_little = (definition.data.endian == Endian::Little))]
+    #[br(parse_with = DataField::parse_data_field, args(message_type, &definition.data.fields, &definition.data.dev_fields, dev_field_descriptions), is_little = (definition.data.endian == Endian::Little))]
     pub values: Vec<DataField>,
 }
 


### PR DESCRIPTION
Hi,

This pull request adds rudimentary support for parsing developer data fields.

Overview of the changes that I have made:

* field_num becomes a `FieldNum` enum instead of a u8
* During parsing, developer data field descriptions are collected in a `HashMap` that maps a `u8` tuple, representing the developer data index and definition number, respectively, to a new `FieldDefinition` struct containing them values plus the FIT base type of the developer data field
* The developer data field descriptions map is passed to `parse_data_field` to correctly parse developer data fields
* Values that represented 'field nums' are updated to be values of the FieldNum::GlobalProfile variant
* Fixed a timestamp out of range bug; however I don't know if this is functionally correct

Please let me know what you think!

Thanks,
Ryan